### PR TITLE
Refactor audio response handling to support local AI models and impro…

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,52 +3,55 @@ PORT=3000
 LOG_LEVEL=info
 DATABASE_URL=postgresql://postgres:postgres@localhost:5432/voicebot?schema=public
 
-# LiveKit Configuration
+# ===========================================
+# LiveKit Configuration (Required)
+# Get free tier at https://livekit.io
+# ===========================================
 LIVEKIT_URL=wss://YOUR-LIVEKIT-HOST
 LIVEKIT_API_KEY=your_livekit_key
 LIVEKIT_API_SECRET=your_livekit_secret
 
 # ===========================================
-# STT (Speech-to-Text) Provider Options
+# STT (Speech-to-Text) - Deepgram Cloud
+# Get API key at https://deepgram.com
 # ===========================================
-# Option 1: Deepgram (cloud - paid)
-# STT_PROVIDER=deepgram
-# STT_MODEL=nova-2
-# DEEPGRAM_API_KEY=your_deepgram_key
+STT_PROVIDER=deepgram
+STT_MODEL=nova-2
+DEEPGRAM_API_KEY=your_deepgram_key
 
-# Option 2: Whisper.cpp (local - free)
-STT_PROVIDER=whispercpp
-WHISPER_BASE_URL=http://whispercpp:9000
-WHISPER_API_STYLE=openai
-WHISPER_MODEL=base
-
-# ===========================================
-# LLM (Language Model) Provider Options
-# ===========================================
-# Option 1: Anthropic Claude (cloud - paid)
-# LLM_PROVIDER=anthropic
-# LLM_MODEL=claude-3-haiku-20240307
-# ANTHROPIC_API_KEY=your_anthropic_key
-
-# Option 2: Ollama (local - free)
-LLM_PROVIDER=ollama
-OLLAMA_BASE_URL=http://ollama:11434
-OLLAMA_MODEL=llama3.1
+# (Optional) Whisper.cpp local fallback
+# STT_PROVIDER=whispercpp
+# WHISPER_BASE_URL=http://whispercpp:9000
+# WHISPER_API_STYLE=openai
+# WHISPER_MODEL=base
 
 # ===========================================
-# TTS (Text-to-Speech) Provider Options
+# LLM (Language Model) - Anthropic Claude
+# Get API key at https://console.anthropic.com
 # ===========================================
-# Option 1: OpenAI TTS (cloud - paid)
-# TTS_PROVIDER=openai
-# TTS_MODEL=gpt-4o-mini-tts
-# OPENAI_TTS_VOICE=alloy
-# OPENAI_API_KEY=your_openai_key
+LLM_PROVIDER=anthropic
+LLM_MODEL=claude-3-5-sonnet-20241022
+ANTHROPIC_API_KEY=your_anthropic_key
 
-# Option 2: Piper (local - free)
-TTS_PROVIDER=piper
-PIPER_BASE_URL=http://piper:5002
-PIPER_VOICE=en_US-lessac
-PIPER_AUDIO_FORMAT=wav
+# (Optional) Ollama local fallback
+# LLM_PROVIDER=ollama
+# OLLAMA_BASE_URL=http://ollama:11434
+# OLLAMA_MODEL=llama3.1
+
+# ===========================================
+# TTS (Text-to-Speech) - OpenAI
+# Get API key at https://platform.openai.com
+# ===========================================
+TTS_PROVIDER=openai
+TTS_MODEL=tts-1
+OPENAI_TTS_VOICE=alloy
+OPENAI_API_KEY=your_openai_key
+
+# (Optional) Piper local fallback
+# TTS_PROVIDER=piper
+# PIPER_BASE_URL=http://piper:5002
+# PIPER_VOICE=en_US-lessac
+# PIPER_AUDIO_FORMAT=wav
 
 # ===========================================
 # Feature Flags

--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,7 @@ yarn-error.log*
 # Docker volumes (local data)
 postgres_data/
 ollama_data/
+piper_data/
 
 # Temporary files
 *.tmp

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,30 +36,36 @@ services:
     command: >-
       sh -c "npx prisma migrate deploy && npx prisma db seed && node dist/index.js"
 
-  ollama:
-    image: ollama/ollama:latest
-    container_name: voicebot_ollama
-    ports:
-      - '11434:11434'
-    volumes:
-      - ollama_data:/root/.ollama
+  # ============================================
+  # OPTIONAL: Local AI Services (commented out)
+  # Uncomment if you want to use local models
+  # instead of cloud APIs (Deepgram, Anthropic, OpenAI)
+  # ============================================
 
-  whispercpp:
-    image: onerahmet/openai-whisper-asr-webservice:latest
-    container_name: voicebot_whisper
-    ports:
-      - '8080:9000'
-    environment:
-      ASR_MODEL: base
-      ASR_ENGINE: openai_whisper
+  # ollama:
+  #   image: ollama/ollama:latest
+  #   container_name: voicebot_ollama
+  #   ports:
+  #     - '11434:11434'
+  #   volumes:
+  #     - ollama_data:/root/.ollama
 
-  piper:
-    build:
-      context: ./piper-service
-    container_name: voicebot_piper
-    ports:
-      - '5002:5002'
+  # whispercpp:
+  #   image: onerahmet/openai-whisper-asr-webservice:latest
+  #   container_name: voicebot_whisper
+  #   ports:
+  #     - '8080:9000'
+  #   environment:
+  #     ASR_MODEL: base
+  #     ASR_ENGINE: openai_whisper
+
+  # piper:
+  #   build:
+  #     context: ./piper-service
+  #   container_name: voicebot_piper
+  #   ports:
+  #     - '5002:5002'
 
 volumes:
   postgres_data:
-  ollama_data:
+  # ollama_data:

--- a/src/agents/VoiceAgent.ts
+++ b/src/agents/VoiceAgent.ts
@@ -1,8 +1,5 @@
 import { AudioFrame, AudioSource, AudioStream, LocalAudioTrack, Room, RoomEvent, Track, TrackKind } from '@livekit/rtc-node';
-import { TrackPublishOptionsSchema } from '@livekit/rtc-node/dist/proto/room_pb.js';
 import { AccessToken } from 'livekit-server-sdk';
-import { create } from '@bufbuild/protobuf';
-
 import { loadEnv } from '../config/env.js';
 import { ConversationLogRepository } from '../data/repositories/ConversationLogRepository.js';
 import { ConversationManager } from '../domain/conversation/ConversationManager.js';

--- a/src/agents/server.ts
+++ b/src/agents/server.ts
@@ -56,7 +56,7 @@ app.get('/health', async (req, res) => {
  * Note: Agent dispatch is now handled by LiveKit Cloud or separate agent service
  */
 app.post('/token', async (req, res) => {
-  const { participantName } = req.body;
+  const { participantName, roomName: clientRoomName } = req.body;
 
   if (!participantName) {
     return res.status(400).json({ error: 'participantName required' });
@@ -65,7 +65,8 @@ app.post('/token', async (req, res) => {
   try {
     // Generate unique identifiers
     const participantIdentity = `helpdesk_user_${Math.floor(Math.random() * 10_000)}`;
-    const roomName = `helpdesk_room_${Math.floor(Math.random() * 10_000)}`;
+    // Use client-provided roomName or generate one
+    const roomName = clientRoomName || `helpdesk_room_${Math.floor(Math.random() * 10_000)}`;
 
     // Create access token
     const at = new AccessToken(config.LIVEKIT_API_KEY, config.LIVEKIT_API_SECRET, {

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -11,21 +11,31 @@ const envSchema = z.object({
   LIVEKIT_URL: z.string().url(),
   LIVEKIT_API_KEY: z.string().min(1),
   LIVEKIT_API_SECRET: z.string().min(1),
-  STT_PROVIDER: z.enum(['deepgram', 'openai', 'whispercpp']).default('whispercpp'),
-  STT_MODEL: z.string().default('base'),
+  // STT Configuration (default: Deepgram cloud)
+  STT_PROVIDER: z.enum(['deepgram', 'openai', 'whispercpp']).default('deepgram'),
+  STT_MODEL: z.string().default('nova-2'),
   DEEPGRAM_API_KEY: z.string().optional(),
+  // Whisper local fallback (optional)
   WHISPER_BASE_URL: z.string().default('http://whispercpp:9000'),
   WHISPER_API_STYLE: z.enum(['whispercpp', 'openai', 'onerahmet']).default('openai'),
   WHISPER_MODEL: z.string().default('base'),
-  LLM_PROVIDER: z.enum(['anthropic', 'openai', 'ollama']).default('ollama'),
-  LLM_MODEL: z.string().default('llama3.1'),
+  // LLM Configuration (default: Anthropic cloud)
+  LLM_PROVIDER: z.enum(['anthropic', 'openai', 'ollama']).default('anthropic'),
+  LLM_MODEL: z.string().default('claude-3-5-sonnet-20241022'),
   ANTHROPIC_API_KEY: z.string().optional(),
   OPENAI_API_KEY: z.string().optional(),
+  // Ollama local fallback (optional)
   OLLAMA_BASE_URL: z.string().default('http://ollama:11434'),
   OLLAMA_MODEL: z.string().default('llama3.1'),
-  TTS_PROVIDER: z.enum(['openai', 'elevenlabs', 'piper']).default('piper'),
+  // TTS Configuration (default: OpenAI cloud)
+  TTS_PROVIDER: z.enum(['openai', 'elevenlabs', 'piper']).default('openai'),
   TTS_MODEL: z.string().default('tts-1'),
   OPENAI_TTS_VOICE: z.string().default('alloy'),
+  // ElevenLabs TTS (10k chars/month free)
+  ELEVENLABS_API_KEY: z.string().optional(),
+  ELEVENLABS_VOICE_ID: z.string().default('21m00Tcm4TlvDq8ikWAM'),
+  ELEVENLABS_MODEL_ID: z.string().default('eleven_turbo_v2_5'),
+  // Piper local fallback (optional)
   PIPER_BASE_URL: z.string().default('http://piper:5002'),
   PIPER_VOICE: z.string().default('en_US-lessac'),
   PIPER_AUDIO_FORMAT: z.enum(['wav', 'mp3']).default('wav'),

--- a/src/run-bot.ts
+++ b/src/run-bot.ts
@@ -1,23 +1,19 @@
 /**
  * Manual Bot Runner
- * This script runs ON THE HOST machine, so it needs to talk to Docker containers via localhost.
- * We override the environment variables programmatically before loading the app.
+ * This script runs ON THE HOST machine, connecting to LiveKit Cloud.
+ * It uses cloud providers (Deepgram, Anthropic, OpenAI) configured via .env
  */
 
-// 1. Force Localhost Networking for this script only
-process.env.PIPER_BASE_URL = 'http://127.0.0.1:5002';
-process.env.WHISPER_BASE_URL = 'http://127.0.0.1:8080';
-process.env.WHISPER_API_STYLE = 'onerahmet'; // Fix 404 error by matching image API
-process.env.OLLAMA_BASE_URL = 'http://127.0.0.1:11434';
-
-// 2. Dynamic imports to ensure env vars are set BEFORE config loads
+// Dynamic imports
 const { AccessToken } = await import('livekit-server-sdk');
 const { VoiceAgent } = await import('./agents/VoiceAgent.js');
 const { loadEnv } = await import('./config/env.js');
 const { logger } = await import('./utils/logger.js');
 
 const config = loadEnv();
-const ROOM_NAME = 'demo-room';
+
+// Allow room name from command line: npx tsx src/run-bot.ts my-room-name
+const ROOM_NAME = process.argv[2] || 'demo-room';
 const AGENT_IDENTITY = 'voice_agent_bot';
 
 async function main() {

--- a/src/services/providers/DeepgramSTTProvider.ts
+++ b/src/services/providers/DeepgramSTTProvider.ts
@@ -20,6 +20,9 @@ export class DeepgramSTTProvider implements STTProvider {
         model: 'nova-2',
         smart_format: true,
         punctuate: true,
+        encoding: 'linear16', // 16-bit signed PCM
+        sample_rate: 16000, // 16kHz from AudioStream
+        channels: 1, // mono
       });
 
       if (error) {

--- a/src/services/providers/ElevenLabsTTSProvider.ts
+++ b/src/services/providers/ElevenLabsTTSProvider.ts
@@ -1,0 +1,84 @@
+import { logger } from '../../utils/logger.js';
+import { TTSProvider, TTSResult } from './types.js';
+
+export class ElevenLabsTTSProvider implements TTSProvider {
+  private apiKey: string;
+  private voiceId: string;
+  private modelId: string;
+
+  // ElevenLabs outputs 24kHz 16-bit mono PCM when using pcm_24000
+  static readonly SAMPLE_RATE = 24000;
+  static readonly CHANNELS = 1;
+  static readonly BITS_PER_SAMPLE = 16;
+
+  constructor(apiKey: string, voiceId = '21m00Tcm4TlvDq8ikWAM', modelId = 'eleven_turbo_v2_5') {
+    this.apiKey = apiKey;
+    this.voiceId = voiceId;
+    this.modelId = modelId;
+  }
+
+  async synthesize(text: string): Promise<TTSResult> {
+    const startTime = Date.now();
+
+    try {
+      const response = await fetch(
+        `https://api.elevenlabs.io/v1/text-to-speech/${this.voiceId}?output_format=pcm_24000`,
+        {
+          method: 'POST',
+          headers: {
+            Accept: 'audio/pcm',
+            'Content-Type': 'application/json',
+            'xi-api-key': this.apiKey,
+          },
+          body: JSON.stringify({
+            text,
+            model_id: this.modelId,
+            voice_settings: {
+              stability: 0.5,
+              similarity_boost: 0.75,
+            },
+          }),
+        },
+      );
+
+      if (!response.ok) {
+        const errorText = await response.text();
+        throw new Error(`ElevenLabs API error: ${response.status} - ${errorText}`);
+      }
+
+      const arrayBuffer = await response.arrayBuffer();
+      const audioBuffer = Buffer.from(arrayBuffer);
+      const duration = Date.now() - startTime;
+
+      logger.debug(
+        {
+          duration,
+          textLength: text.length,
+          audioSize: audioBuffer.length,
+          format: 'pcm_24khz_16bit_mono',
+        },
+        'elevenlabs tts synthesis completed',
+      );
+
+      return {
+        audio: audioBuffer,
+        duration,
+        metadata: {
+          provider: 'elevenlabs',
+          model: this.modelId,
+          voice: this.voiceId,
+          sampleRate: ElevenLabsTTSProvider.SAMPLE_RATE,
+          channels: ElevenLabsTTSProvider.CHANNELS,
+          format: 'pcm',
+        },
+      };
+    } catch (error) {
+      logger.error({ err: error }, 'elevenlabs tts synthesis failed');
+      throw error;
+    }
+  }
+
+  async close(): Promise<void> {
+    // ElevenLabs client doesn't require explicit cleanup
+  }
+}

--- a/src/services/providers/ProviderFactory.ts
+++ b/src/services/providers/ProviderFactory.ts
@@ -3,6 +3,7 @@ import { logger } from '../../utils/logger.js';
 
 import { AnthropicLLMProvider } from './AnthropicLLMProvider.js';
 import { DeepgramSTTProvider } from './DeepgramSTTProvider.js';
+import { ElevenLabsTTSProvider } from './ElevenLabsTTSProvider.js';
 import { OllamaLLMProvider } from './OllamaLLMProvider.js';
 import { OpenAITTSProvider } from './OpenAITTSProvider.js';
 import { PiperTTSProvider } from './PiperTTSProvider.js';
@@ -108,8 +109,18 @@ export class ProviderFactory {
         );
 
       case 'elevenlabs':
-        logger.info('initializing ElevenLabs TTS provider (not implemented)');
-        throw new Error('ElevenLabs TTS provider not implemented yet');
+        if (!this.config.ELEVENLABS_API_KEY) {
+          throw new Error('ELEVENLABS_API_KEY is required for ElevenLabs TTS');
+        }
+        logger.info(
+          { voice: this.config.ELEVENLABS_VOICE_ID, model: this.config.ELEVENLABS_MODEL_ID },
+          'initializing ElevenLabs TTS provider',
+        );
+        return new ElevenLabsTTSProvider(
+          this.config.ELEVENLABS_API_KEY,
+          this.config.ELEVENLABS_VOICE_ID,
+          this.config.ELEVENLABS_MODEL_ID,
+        );
 
       case 'piper':
         logger.info(

--- a/web/client.js
+++ b/web/client.js
@@ -64,7 +64,8 @@ async function requestMicrophonePermission() {
 // Start call
 async function startCall() {
   const participantName = participantNameInput.value.trim() || 'Guest User';
-  const roomName = `helpdesk-${Date.now()}`;
+  // Use demo-room to match the bot's default room
+  const roomName = 'demo-room';
 
   try {
     updateStatus('Requesting microphone access...', 'yellow');

--- a/web/client.js
+++ b/web/client.js
@@ -64,8 +64,9 @@ async function requestMicrophonePermission() {
 // Start call
 async function startCall() {
   const participantName = participantNameInput.value.trim() || 'Guest User';
-  // Use demo-room to match the bot's default room
-  const roomName = 'demo-room';
+  // Determine room name: allow override via URL query parameter, default to demo-room to match the bot's default room
+  const urlParams = new URLSearchParams(window.location.search);
+  const roomName = urlParams.get('roomName') || 'demo-room';
 
   try {
     updateStatus('Requesting microphone access...', 'yellow');


### PR DESCRIPTION
This pull request introduces significant improvements to the default configuration and cloud-first experience of the voicebot application, while also enhancing the real-time voice pipeline and developer ergonomics. The main changes include making cloud providers (Deepgram, Anthropic, OpenAI) the default for STT, LLM, and TTS, refactoring the `VoiceAgent` to stream TTS audio directly via LiveKit, improving logging and diagnostics, and simplifying local development setup by making local AI services optional.

**Configuration and Defaults (Cloud-first):**
- Updated `.env.example` and environment schema to use Deepgram (STT), Anthropic Claude (LLM), and OpenAI (TTS) as defaults, with clear instructions and commented-out local options for Whisper.cpp, Ollama, and Piper. [[1]](diffhunk://#diff-a3046da0d15a27e89f2afe639b25748a7ad4d9290af3e7b1b6c1a5533c8f0a8cL6-R54) [[2]](diffhunk://#diff-0628e9bc652476c15d1024481f1eaebb8f1ca780b4ac24da3b2b20651662968aL14-R38)
- Refactored `docker-compose.yml` to comment out local AI service containers (Ollama, Whisper.cpp, Piper) by default, making them optional for developers who want to run local models.

**VoiceAgent Real-time Audio Pipeline:**
- Major refactor to `VoiceAgent.ts` to publish TTS audio directly to the LiveKit room using an audio track, instead of sending audio as data messages. This includes:
  - Initializing an `AudioSource` and `LocalAudioTrack` for TTS playback.
  - Converting PCM TTS output to audio frames and streaming them via LiveKit. [[1]](diffhunk://#diff-7146b5038f88ce163bc7f5f354280e68e2277dc9f47abf1d5a8f84f4ae87bd4bL1-R4) [[2]](diffhunk://#diff-7146b5038f88ce163bc7f5f354280e68e2277dc9f47abf1d5a8f84f4ae87bd4bR28-R31) [[3]](diffhunk://#diff-7146b5038f88ce163bc7f5f354280e68e2277dc9f47abf1d5a8f84f4ae87bd4bR47-R51) [[4]](diffhunk://#diff-7146b5038f88ce163bc7f5f354280e68e2277dc9f47abf1d5a8f84f4ae87bd4bL452-R636)
  - Improved speech detection (VAD) sensitivity and reduced latency for STT input. [[1]](diffhunk://#diff-7146b5038f88ce163bc7f5f354280e68e2277dc9f47abf1d5a8f84f4ae87bd4bL111-R202) [[2]](diffhunk://#diff-7146b5038f88ce163bc7f5f354280e68e2277dc9f47abf1d5a8f84f4ae87bd4bR224-R241) [[3]](diffhunk://#diff-7146b5038f88ce163bc7f5f354280e68e2277dc9f47abf1d5a8f84f4ae87bd4bL177-R265)
  - Enhanced resource cleanup, including unpublishing the audio track on shutdown.

**Logging and Diagnostics:**
- Added detailed logging throughout the audio pipeline for easier debugging and monitoring:
  - Logs for every 50th audio frame, STT/LLM/TTS calls and responses, and playback events. [[1]](diffhunk://#diff-7146b5038f88ce163bc7f5f354280e68e2277dc9f47abf1d5a8f84f4ae87bd4bL111-R202) [[2]](diffhunk://#diff-7146b5038f88ce163bc7f5f354280e68e2277dc9f47abf1d5a8f84f4ae87bd4bR224-R241) [[3]](diffhunk://#diff-7146b5038f88ce163bc7f5f354280e68e2277dc9f47abf1d5a8f84f4ae87bd4bL177-R265) [[4]](diffhunk://#diff-7146b5038f88ce163bc7f5f354280e68e2277dc9f47abf1d5a8f84f4ae87bd4bR353-R365) [[5]](diffhunk://#diff-7146b5038f88ce163bc7f5f354280e68e2277dc9f47abf1d5a8f84f4ae87bd4bR389-R393)

**Developer Experience:**
- Updated `src/run-bot.ts` to remove hardcoded localhost overrides and allow specifying the room name via command line, aligning with the new cloud-first defaults.
- Improved `/token` endpoint to accept a client-provided room name for better integration with frontend clients. [[1]](diffhunk://#diff-bb2967d239210ef9d9b35d79ab7314db2aab3b0801c2bcab4d35923841516203L59-R59) [[2]](diffhunk://#diff-bb2967d239210ef9d9b35d79ab7314db2aab3b0801c2bcab4d35923841516203L68-R69)

**Other Improvements:**
- Updated comments and documentation in config files and code to clarify usage and setup for both cloud and local options. [[1]](diffhunk://#diff-a3046da0d15a27e89f2afe639b25748a7ad4d9290af3e7b1b6c1a5533c8f0a8cL6-R54) [[2]](diffhunk://#diff-0628e9bc652476c15d1024481f1eaebb8f1ca780b4ac24da3b2b20651662968aL14-R38)

**References:**  
[[1]](diffhunk://#diff-a3046da0d15a27e89f2afe639b25748a7ad4d9290af3e7b1b6c1a5533c8f0a8cL6-R54) [[2]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L39-R71) [[3]](diffhunk://#diff-0628e9bc652476c15d1024481f1eaebb8f1ca780b4ac24da3b2b20651662968aL14-R38) [[4]](diffhunk://#diff-7146b5038f88ce163bc7f5f354280e68e2277dc9f47abf1d5a8f84f4ae87bd4bL1-R4) [[5]](diffhunk://#diff-7146b5038f88ce163bc7f5f354280e68e2277dc9f47abf1d5a8f84f4ae87bd4bR28-R31) [[6]](diffhunk://#diff-7146b5038f88ce163bc7f5f354280e68e2277dc9f47abf1d5a8f84f4ae87bd4bR47-R51) [[7]](diffhunk://#diff-7146b5038f88ce163bc7f5f354280e68e2277dc9f47abf1d5a8f84f4ae87bd4bL69-R140) [[8]](diffhunk://#diff-7146b5038f88ce163bc7f5f354280e68e2277dc9f47abf1d5a8f84f4ae87bd4bL111-R202) [[9]](diffhunk://#diff-7146b5038f88ce163bc7f5f354280e68e2277dc9f47abf1d5a8f84f4ae87bd4bR224-R241) [[10]](diffhunk://#diff-7146b5038f88ce163bc7f5f354280e68e2277dc9f47abf1d5a8f84f4ae87bd4bL177-R265) [[11]](diffhunk://#diff-7146b5038f88ce163bc7f5f354280e68e2277dc9f47abf1d5a8f84f4ae87bd4bR353-R365) [[12]](diffhunk://#diff-7146b5038f88ce163bc7f5f354280e68e2277dc9f47abf1d5a8f84f4ae87bd4bR389-R393) [[13]](diffhunk://#diff-7146b5038f88ce163bc7f5f354280e68e2277dc9f47abf1d5a8f84f4ae87bd4bL452-R636) [[14]](diffhunk://#diff-bb2967d239210ef9d9b35d79ab7314db2aab3b0801c2bcab4d35923841516203L59-R59) [[15]](diffhunk://#diff-bb2967d239210ef9d9b35d79ab7314db2aab3b0801c2bcab4d35923841516203L68-R69) [[16]](diffhunk://#diff-cb8d9ff544a66dc0ddcd397092005f20fada12643be3edb4688b00dd43916a47L3-R16)…ve TTS integration